### PR TITLE
Update draggable to 2.0-SNAPSHOT

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -32,35 +32,35 @@
         <dependency>
             <groupId>com.arcbees.gquery</groupId>
             <artifactId>draggable</artifactId>
-		</dependency>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-               <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-               <configuration>
-                 <additionalClasspathElements>
-                   <additionalClasspathElement>\${project.build.sourceDirectory}</additionalClasspathElement>
-                   <additionalClasspathElement>\${project.build.testSourceDirectory}</additionalClasspathElement>
-                 </additionalClasspathElements>
-                 <useManifestOnlyJar>false</useManifestOnlyJar>
-                 <forkMode>always</forkMode>
+                <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>\${project.build.sourceDirectory}</additionalClasspathElement>
+                        <additionalClasspathElement>\${project.build.testSourceDirectory}</additionalClasspathElement>
+                    </additionalClasspathElements>
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <forkMode>always</forkMode>
 
-                 <!-- Folder for generated testing stuff -->
-                 <systemProperties>
-                   <property>
-                     <name>gwt.args</name>
+                    <!-- Folder for generated testing stuff -->
+                    <systemProperties>
+                        <property>
+                            <name>gwt.args</name>
                             <value>-war target/www</value>
-                   </property>
-                 </systemProperties>
-               </configuration>
+                        </property>
+                    </systemProperties>
+                </configuration>
             </plugin>
             <plugin>
-              <artifactId>maven-clean-plugin</artifactId>
-              <configuration>
-                <filesets>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
                         <fileset>
                             <directory>tomcat</directory>
                         </fileset>
@@ -70,8 +70,8 @@
                         <fileset>
                             <directory>.gwt-tmp</directory>
                         </fileset>
-                </filesets>
-              </configuration>
+                    </filesets>
+                </configuration>
             </plugin>
         </plugins>
         <resources>
@@ -82,5 +82,5 @@
                 <directory>${basedir}/src/main/resources</directory>
             </resource>
         </resources>
-   </build>
+    </build>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,37 +30,37 @@
             <artifactId>gwtquery</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.gwtquery.plugins</groupId>
-            <artifactId>draggable-plugin</artifactId>
-        </dependency>
+            <groupId>com.arcbees.gquery</groupId>
+            <artifactId>draggable</artifactId>
+		</dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
+               <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <additionalClasspathElements>
-                        <additionalClasspathElement>\${project.build.sourceDirectory}</additionalClasspathElement>
-                        <additionalClasspathElement>\${project.build.testSourceDirectory}</additionalClasspathElement>
-                    </additionalClasspathElements>
-                    <useManifestOnlyJar>false</useManifestOnlyJar>
-                    <forkMode>always</forkMode>
+               <configuration>
+                 <additionalClasspathElements>
+                   <additionalClasspathElement>\${project.build.sourceDirectory}</additionalClasspathElement>
+                   <additionalClasspathElement>\${project.build.testSourceDirectory}</additionalClasspathElement>
+                 </additionalClasspathElements>
+                 <useManifestOnlyJar>false</useManifestOnlyJar>
+                 <forkMode>always</forkMode>
 
-                    <!-- Folder for generated testing stuff -->
-                    <systemProperties>
-                        <property>
-                            <name>gwt.args</name>
+                 <!-- Folder for generated testing stuff -->
+                 <systemProperties>
+                   <property>
+                     <name>gwt.args</name>
                             <value>-war target/www</value>
-                        </property>
-                    </systemProperties>
-                </configuration>
+                   </property>
+                 </systemProperties>
+               </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
+              <artifactId>maven-clean-plugin</artifactId>
+              <configuration>
+                <filesets>
                         <fileset>
                             <directory>tomcat</directory>
                         </fileset>
@@ -70,8 +70,8 @@
                         <fileset>
                             <directory>.gwt-tmp</directory>
                         </fileset>
-                    </filesets>
-                </configuration>
+                </filesets>
+              </configuration>
             </plugin>
         </plugins>
         <resources>
@@ -82,5 +82,5 @@
                 <directory>${basedir}/src/main/resources</directory>
             </resource>
         </resources>
-    </build>
+   </build>
 </project>

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/DragAndDropManagerImpl.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/DragAndDropManagerImpl.java
@@ -37,9 +37,9 @@ import gwtquery.plugins.droppable.client.events.DragAndDropContext;
 
 /**
  * Implementation of the {@link DragAndDropManager} for drop operations
- * 
+ *
  * @author Julien Dramaix (julien.dramaix@gmail.com)
- * 
+ *
  */
 public class DragAndDropManagerImpl extends DragAndDropManager {
 
@@ -53,7 +53,7 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
 
   /**
    * Link a droppable with the specified scope <code>scope</code>
-   * 
+   *
    * @param droppable
    * @param scope
    */
@@ -69,8 +69,8 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
 
   /**
    * Method called when the draggable is being dragged
-   * 
-   * @param draggable
+   *
+   * @param ctx
    * @param e
    */
   @Override
@@ -93,8 +93,8 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
 
   /**
    * Method called when the draggable was dropped
-   * 
-   * @param draggable
+   *
+   * @param ctx
    * @param e
    * @return
    */
@@ -122,7 +122,7 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
 
   /**
    * Return the list of droppable elements with the scope <code>scope</code>
-   * 
+   *
    * @param scope
    * @return
    */
@@ -152,8 +152,7 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
       DroppableOptions droppableOptions = droppableHandler.getOptions();
       AcceptFunction accept = droppableOptions.getAccept();
       if (droppableOptions.isDisabled()
-          || (accept != null && !accept.acceptDrop(new DragAndDropContext(ctx,
-              droppable)))) {
+          || (accept != null && !accept.acceptDrop(new DragAndDropContext(ctx, droppable)))) {
         continue;
       }
 
@@ -180,9 +179,7 @@ public class DragAndDropManagerImpl extends DragAndDropManager {
           droppableHandler.activate(dndContext, e);
         }
       }
-
     }
-
   }
 
   @Override

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/DroppableHandler.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/DroppableHandler.java
@@ -82,14 +82,12 @@ public class DroppableHandler {
     }
 
     for (Element draggable : ctx.getSelectedDraggables()) {
-
       if (options.getDraggableHoverClass() != null) {
         $(draggable).data(options.getDraggableHoverClass(), new Integer(0));
       }
     }
 
     trigger(new ActivateDroppableEvent(ctx), options.getOnActivate(), ctx);
-
   }
 
   public void deactivate(DragAndDropContext ctx, GqEvent e) {
@@ -111,7 +109,6 @@ public class DroppableHandler {
 
       trigger(new DeactivateDroppableEvent(ctx), options.getOnDeactivate(), ctx);
     }
-
   }
 
   public void drag(DragAndDropContext ctx, GqEvent e) {
@@ -143,8 +140,7 @@ public class DroppableHandler {
       droppableParents = $(droppable).parents(
           "." + CssClassNames.GWTQUERY_DROPPABLE);
       if (droppableParents.length() > 0) {
-        parentDroppableHandler = DroppableHandler.getInstance(droppableParents
-            .get(0));
+        parentDroppableHandler = DroppableHandler.getInstance(droppableParents.get(0));
         parentDroppableHandler.greedyChild = (c == PositionStatus.IS_OVER);
         parentDndContext = new DragAndDropContext(ctx, droppableParents.get(0));
       }
@@ -171,11 +167,9 @@ public class DroppableHandler {
       parentDroppableHandler.isOver = true;
       parentDroppableHandler.over(parentDndContext, e);
     }
-
   }
 
   public boolean drop(final DragAndDropContext ctx, boolean alreadyDrop, GqEvent e) {
-
     Element draggable = ctx.getDraggable();
 
     if (options == null) {
@@ -185,9 +179,7 @@ public class DroppableHandler {
     boolean drop = false;
 
     if (!options.isDisabled() && visible) {
-      if (intersect(draggable) && !checkChildrenIntersection(ctx)
-          && isDraggableAccepted(ctx)) {
-
+      if (intersect(draggable) && !checkChildrenIntersection(ctx) && isDraggableAccepted(ctx)) {
         // we will use a deferredComand to trigger the drop event a the end of
         // the drag and drop operation !!
         // it's to ensure that the rest of the dnd operation will be done
@@ -252,15 +244,11 @@ public class DroppableHandler {
 
       if (options.getDraggableHoverClass() != null) {
         for (Element draggable : ctx.getSelectedDraggables()) {
-          Integer counter = $(draggable).data(options.getDraggableHoverClass(),
-              Integer.class);
-          $(draggable).data(options.getDraggableHoverClass(),
-              new Integer(--counter));
+          Integer counter = $(draggable).data(options.getDraggableHoverClass(), Integer.class);
+          $(draggable).data(options.getDraggableHoverClass(), new Integer(--counter));
           if (counter == 0) {
-            DraggableHandler dragHandler = DraggableHandler
-                .getInstance(draggable);
-            dragHandler.getHelper().removeClass(
-                options.getDraggableHoverClass());
+            DraggableHandler dragHandler = DraggableHandler.getInstance(draggable);
+            dragHandler.getHelper().removeClass(options.getDraggableHoverClass());
           }
         }
       }
@@ -283,13 +271,10 @@ public class DroppableHandler {
       }
       if (options.getDraggableHoverClass() != null) {
         for (Element draggable : ctx.getSelectedDraggables()) {
-          DraggableHandler dragHandler = DraggableHandler
-              .getInstance(draggable);
+          DraggableHandler dragHandler = DraggableHandler.getInstance(draggable);
           dragHandler.getHelper().addClass(options.getDraggableHoverClass());
-          Integer counter = $(draggable).data(options.getDraggableHoverClass(),
-              Integer.class);
-          $(draggable).data(options.getDraggableHoverClass(),
-              new Integer(++counter));
+          Integer counter = $(draggable).data(options.getDraggableHoverClass(), Integer.class);
+          $(draggable).data(options.getDraggableHoverClass(), new Integer(++counter));
         }
       }
 
@@ -341,8 +326,7 @@ public class DroppableHandler {
         continue;
       }
       handler.setDroppableOffset($(e).offset());
-      DraggableHandler draggableHandler = DraggableHandler
-          .getInstance(draggable);
+      DraggableHandler draggableHandler = DraggableHandler.getInstance(draggable);
       DroppableOptions dropOpt = handler.getOptions();
       DraggableOptions dragOpt = draggableHandler.getOptions();
       if (dropOpt.isGreedy() && !dropOpt.isDisabled()
@@ -362,11 +346,9 @@ public class DroppableHandler {
     DraggableHandler dragHandler = DraggableHandler.getInstance(draggable);
 
     int draggableLeft = dragHandler.getAbsolutePosition().left;
-    int draggableRight = draggableLeft
-        + dragHandler.getHelperDimension().getWidth();
+    int draggableRight = draggableLeft + dragHandler.getHelperDimension().getWidth();
     int draggableTop = dragHandler.getAbsolutePosition().top;
-    int draggableBottom = draggableTop
-        + dragHandler.getHelperDimension().getHeight();
+    int draggableBottom = draggableTop + dragHandler.getHelperDimension().getHeight();
 
     int droppableLeft = droppableOffset.left;
     int droppableRight = droppableLeft + droppableDimension.getWidth();

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/DroppableHandler.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/DroppableHandler.java
@@ -28,7 +28,6 @@ import com.google.gwt.query.client.plugins.events.GqEvent;
 
 import static gwtquery.plugins.droppable.client.Droppable.DROPPABLE_HANDLER_KEY;
 
-import gwtquery.plugins.draggable.client.DragAndDropManager;
 import gwtquery.plugins.draggable.client.DraggableHandler;
 import gwtquery.plugins.draggable.client.DraggableOptions;
 import gwtquery.plugins.droppable.client.Droppable.CssClassNames;
@@ -75,43 +74,50 @@ public class DroppableHandler {
 
   }
 
-  public void activate(Element droppable, GqEvent e) {
+  public void activate(DragAndDropContext ctx, GqEvent e) {
+    Element droppable = ctx.getDroppable();
+
     if (options.getActiveClass() != null) {
       droppable.addClassName(options.getActiveClass());
     }
-    Element draggable = DragAndDropManager.getInstance().getCurrentDraggable();
-    if (draggable != null) {
+
+    for (Element draggable : ctx.getSelectedDraggables()) {
+
       if (options.getDraggableHoverClass() != null) {
         $(draggable).data(options.getDraggableHoverClass(), new Integer(0));
       }
-
-      DragAndDropContext ctx = new DragAndDropContext(draggable, droppable);
-      trigger(new ActivateDroppableEvent(ctx), options.getOnActivate(), ctx);
     }
+
+    trigger(new ActivateDroppableEvent(ctx), options.getOnActivate(), ctx);
+
   }
 
-  public void deactivate(Element droppable, GqEvent e) {
+  public void deactivate(DragAndDropContext ctx, GqEvent e) {
+    Element droppable = ctx.getDroppable();
+
     if (options.getActiveClass() != null) {
       droppable.removeClassName(options.getActiveClass());
     }
     if (options.getDroppableHoverClass() != null) {
       droppable.removeClassName(options.getDroppableHoverClass());
     }
-    Element draggable = DragAndDropManager.getInstance().getCurrentDraggable();
-    if (draggable != null) {
+
+    for (Element draggable : ctx.getSelectedDraggables()) {
       if (options.getDraggableHoverClass() != null) {
         DraggableHandler dragHandler = DraggableHandler.getInstance(draggable);
         dragHandler.getHelper().removeClass(options.getDraggableHoverClass());
         $(draggable).removeData(options.getDraggableHoverClass());
       }
 
-      DragAndDropContext ctx = new DragAndDropContext(draggable, droppable);
       trigger(new DeactivateDroppableEvent(ctx), options.getOnDeactivate(), ctx);
     }
 
   }
 
-  public void drag(Element droppable, Element draggable, GqEvent e) {
+  public void drag(DragAndDropContext ctx, GqEvent e) {
+    Element droppable = ctx.getDroppable();
+    Element draggable = ctx.getDraggable();
+
     if (options.isDisabled() || greedyChild || !visible) {
       return;
     }
@@ -129,6 +135,7 @@ public class DroppableHandler {
     }
 
     DroppableHandler parentDroppableHandler = null;
+    DragAndDropContext parentDndContext = null;
     GQuery droppableParents = null;
     if (options.isGreedy()) {
       // TODO maybe filter the parent with droppable data instead of test on css
@@ -139,35 +146,38 @@ public class DroppableHandler {
         parentDroppableHandler = DroppableHandler.getInstance(droppableParents
             .get(0));
         parentDroppableHandler.greedyChild = (c == PositionStatus.IS_OVER);
+        parentDndContext = new DragAndDropContext(ctx, droppableParents.get(0));
       }
     }
 
     if (parentDroppableHandler != null && c == PositionStatus.IS_OVER) {
       parentDroppableHandler.isOver = false;
       parentDroppableHandler.isOut = true;
-      parentDroppableHandler.out(droppableParents.get(0), draggable, e);
+      parentDroppableHandler.out(parentDndContext, e);
     }
 
     if (c == PositionStatus.IS_OUT) {
       isOut = true;
       isOver = false;
-      out(droppable, draggable, e);
+      out(ctx, e);
     } else {
       isOver = true;
       isOut = false;
-      over(droppable, draggable, e);
+      over(ctx, e);
     }
 
     if (parentDroppableHandler != null && c == PositionStatus.IS_OUT) {
       parentDroppableHandler.isOut = false;
       parentDroppableHandler.isOver = true;
-      parentDroppableHandler.over(droppableParents.get(0), draggable, e);
+      parentDroppableHandler.over(parentDndContext, e);
     }
 
   }
 
-  public boolean drop(Element droppable, Element draggable, GqEvent e,
-      boolean alreadyDrop) {
+  public boolean drop(final DragAndDropContext ctx, boolean alreadyDrop, GqEvent e) {
+
+    Element draggable = ctx.getDraggable();
+
     if (options == null) {
       return false;
     }
@@ -175,12 +185,8 @@ public class DroppableHandler {
     boolean drop = false;
 
     if (!options.isDisabled() && visible) {
-      if (intersect(draggable)
-          && !checkChildrenIntersection(droppable, draggable)
-          && isDraggableAccepted(droppable, draggable)) {
-
-        final DragAndDropContext ctx = new DragAndDropContext(draggable,
-            droppable);
+      if (intersect(draggable) && !checkChildrenIntersection(ctx)
+          && isDraggableAccepted(ctx)) {
 
         // we will use a deferredComand to trigger the drop event a the end of
         // the drag and drop operation !!
@@ -198,10 +204,10 @@ public class DroppableHandler {
 
       }
 
-      if (drop || isDraggableAccepted(droppable, draggable)) {
+      if (drop || isDraggableAccepted(ctx)) {
         isOut = true;
         isOver = false;
-        deactivate(droppable, e);
+        deactivate(ctx, e);
       }
     }
     return drop;
@@ -231,54 +237,62 @@ public class DroppableHandler {
     return visible;
   }
 
-  public void out(Element droppable, Element currentDraggable, GqEvent e) {
+  public void out(DragAndDropContext ctx, GqEvent e) {
+    Element droppable = ctx.getDroppable();
+    Element currentDraggable = ctx.getDraggable();
+
     if (currentDraggable == null || currentDraggable == droppable) {
       return;
     }
 
-    if (isDraggableAccepted(droppable, currentDraggable)) {
+    if (isDraggableAccepted(ctx)) {
       if (options.getDroppableHoverClass() != null) {
         droppable.removeClassName(options.getDroppableHoverClass());
       }
+
       if (options.getDraggableHoverClass() != null) {
-        Integer counter = $(currentDraggable).data(
-            options.getDraggableHoverClass(), Integer.class);
-        $(currentDraggable).data(options.getDraggableHoverClass(),
-            new Integer(--counter));
-        if (counter == 0) {
-          DraggableHandler dragHandler = DraggableHandler
-              .getInstance(currentDraggable);
-          dragHandler.getHelper().removeClass(options.getDraggableHoverClass());
+        for (Element draggable : ctx.getSelectedDraggables()) {
+          Integer counter = $(draggable).data(options.getDraggableHoverClass(),
+              Integer.class);
+          $(draggable).data(options.getDraggableHoverClass(),
+              new Integer(--counter));
+          if (counter == 0) {
+            DraggableHandler dragHandler = DraggableHandler
+                .getInstance(draggable);
+            dragHandler.getHelper().removeClass(
+                options.getDraggableHoverClass());
+          }
         }
       }
 
-      DragAndDropContext ctx = new DragAndDropContext(currentDraggable,
-          droppable);
       trigger(new OutDroppableEvent(ctx), options.getOnOut(), ctx);
     }
   }
 
-  public void over(Element droppable, Element currentDraggable, GqEvent e) {
+  public void over(DragAndDropContext ctx, GqEvent e) {
+    Element droppable = ctx.getDroppable();
+    Element currentDraggable = ctx.getDraggable();
 
     if (currentDraggable == null || currentDraggable == droppable) {
       return;
     }
 
-    if (isDraggableAccepted(droppable, currentDraggable)) {
+    if (isDraggableAccepted(ctx)) {
       if (options.getDroppableHoverClass() != null) {
         droppable.addClassName(options.getDroppableHoverClass());
       }
       if (options.getDraggableHoverClass() != null) {
-        DraggableHandler dragHandler = DraggableHandler
-            .getInstance(currentDraggable);
-        dragHandler.getHelper().addClass(options.getDraggableHoverClass());
-        Integer counter = $(currentDraggable).data(
-            options.getDraggableHoverClass(), Integer.class);
-        $(currentDraggable).data(options.getDraggableHoverClass(),
-            new Integer(++counter));
+        for (Element draggable : ctx.getSelectedDraggables()) {
+          DraggableHandler dragHandler = DraggableHandler
+              .getInstance(draggable);
+          dragHandler.getHelper().addClass(options.getDraggableHoverClass());
+          Integer counter = $(draggable).data(options.getDraggableHoverClass(),
+              Integer.class);
+          $(draggable).data(options.getDraggableHoverClass(),
+              new Integer(++counter));
+        }
       }
-      DragAndDropContext ctx = new DragAndDropContext(currentDraggable,
-          droppable);
+
       trigger(new OverDroppableEvent(ctx), options.getOnOver(), ctx);
     }
 
@@ -316,7 +330,9 @@ public class DroppableHandler {
 
   }
 
-  private boolean checkChildrenIntersection(Element droppable, Element draggable) {
+  private boolean checkChildrenIntersection(DragAndDropContext ctx) {
+    Element droppable = ctx.getDroppable();
+    Element draggable = ctx.getDraggable();
 
     for (Element e : $(droppable).find("*").not(".ui-draggable-dragging")
         .elements()) {
@@ -331,8 +347,7 @@ public class DroppableHandler {
       DraggableOptions dragOpt = draggableHandler.getOptions();
       if (dropOpt.isGreedy() && !dropOpt.isDisabled()
           && dropOpt.getScope().equals(dragOpt.getScope())
-          && handler.isDraggableAccepted(droppable, draggable)
-          && handler.intersect(draggable)) {
+          && handler.isDraggableAccepted(ctx) && handler.intersect(draggable)) {
         return true;
       }
 
@@ -346,10 +361,10 @@ public class DroppableHandler {
     }
     DraggableHandler dragHandler = DraggableHandler.getInstance(draggable);
 
-    int draggableLeft = dragHandler.getAbsPosition().left;
+    int draggableLeft = dragHandler.getAbsolutePosition().left;
     int draggableRight = draggableLeft
         + dragHandler.getHelperDimension().getWidth();
-    int draggableTop = dragHandler.getAbsPosition().top;
+    int draggableTop = dragHandler.getAbsolutePosition().top;
     int draggableBottom = draggableTop
         + dragHandler.getHelperDimension().getHeight();
 
@@ -389,10 +404,9 @@ public class DroppableHandler {
     return true;
   }
 
-  private boolean isDraggableAccepted(Element droppable, Element draggable) {
+  private boolean isDraggableAccepted(DragAndDropContext ctx) {
     AcceptFunction accept = options.getAccept();
-    return accept != null
-        && accept.acceptDrop(new DragAndDropContext(draggable, droppable));
+    return accept != null && accept.acceptDrop(ctx);
   }
 
   private void trigger(AbstractDroppableEvent<?> e, DroppableFunction callback,

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/AbstractDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/AbstractDroppableEvent.java
@@ -22,6 +22,9 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
+import java.util.List;
+
+import gwtquery.plugins.draggable.client.events.DragContext;
 import gwtquery.plugins.draggable.client.gwt.DraggableWidget;
 import gwtquery.plugins.droppable.client.gwt.DroppableWidget;
 
@@ -41,8 +44,8 @@ public abstract class AbstractDroppableEvent<H extends EventHandler> extends
     this.dragAndDropContext = context;
   }
 
-  public AbstractDroppableEvent(Element droppable, Element draggable) {
-    this.dragAndDropContext = new DragAndDropContext(draggable, droppable);
+  public AbstractDroppableEvent(Element droppable, DragContext ctx) {
+    this.dragAndDropContext = new DragAndDropContext(ctx, droppable);
   }
 
   public DragAndDropContext getDragDropContext() {
@@ -87,6 +90,15 @@ public abstract class AbstractDroppableEvent<H extends EventHandler> extends
 
   /**
    * 
+   * @return the DOM element used for dragging display
+   */
+  public Element getDragHelper() {
+    assert dragAndDropContext != null : "DragAndDropContext cannot be null";
+    return dragAndDropContext.getHelper();
+  }
+
+  /**
+   * 
    * @return the droppable DOM element
    */
   public Element getDroppable() {
@@ -122,11 +134,23 @@ public abstract class AbstractDroppableEvent<H extends EventHandler> extends
   }
   
   /**
-   * 
-   * @return the DOM element used for dragging display
+   *
+   * @return the list of selected draggables.
    */
-  public Element getDragHelper() {
+  public List<Element> getSelectedDraggables() {
     assert dragAndDropContext != null : "DragAndDropContext cannot be null";
-    return dragAndDropContext.getHelper();
+    return dragAndDropContext.getSelectedDraggables();
   }
+
+  /**
+   * @return the draggable element that initiate the drag operation (i.e. the
+   *         clicked element)
+   */
+  public Element getInitialDraggable() {
+    assert dragAndDropContext != null : "DragAndDropContext cannot be null";
+    return dragAndDropContext.getInitialDraggable();
+  }
+
+  
+  
 }

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/AbstractDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/AbstractDroppableEvent.java
@@ -150,7 +150,4 @@ public abstract class AbstractDroppableEvent<H extends EventHandler> extends
     assert dragAndDropContext != null : "DragAndDropContext cannot be null";
     return dragAndDropContext.getInitialDraggable();
   }
-
-  
-  
 }

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/ActivateDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/ActivateDroppableEvent.java
@@ -18,6 +18,8 @@ package gwtquery.plugins.droppable.client.events;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 
+import gwtquery.plugins.draggable.client.events.DragContext;
+
 /**
  * Event fired when a droppable element is activated.
  * 
@@ -38,8 +40,8 @@ public class ActivateDroppableEvent
     super(ctx);
   }
 
-  public ActivateDroppableEvent(Element droppable, Element draggable) {
-    super(droppable, draggable);
+  public ActivateDroppableEvent(Element droppable, DragContext dragCtx) {
+    super(droppable, dragCtx);
   }
 
   @Override

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DeactivateDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DeactivateDroppableEvent.java
@@ -18,6 +18,8 @@ package gwtquery.plugins.droppable.client.events;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 
+import gwtquery.plugins.draggable.client.events.DragContext;
+
 /**
  * Event fired when a droppable element is deactivated.
  * 
@@ -38,8 +40,8 @@ public class DeactivateDroppableEvent
     super(ctx);
   }
 
-  public DeactivateDroppableEvent(Element droppable, Element draggable) {
-    super(droppable, draggable);
+  public DeactivateDroppableEvent(Element droppable, DragContext dragCtx) {
+    super(droppable, dragCtx);
   }
 
   @Override

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DragAndDropContext.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DragAndDropContext.java
@@ -33,8 +33,8 @@ public class DragAndDropContext extends DragContext {
 
   private Element droppable;
 
-  public DragAndDropContext(Element draggable, Element droppable) {
-    super(draggable);
+  public DragAndDropContext(DragContext ctx, Element droppable) {
+    super(ctx);
     this.droppable = droppable;
   }
 

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DropEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DropEvent.java
@@ -18,10 +18,12 @@ package gwtquery.plugins.droppable.client.events;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 
+import gwtquery.plugins.draggable.client.events.DragContext;
+
 /**
  * Event fired when an acceptable draggable is dropped on a droppable.
  * 
- * @author Julien Dramaix (julien.dramaix@gmail.com)
+ * @author Julien Dramaix (julien.dramaix@gmail.com, @jdramaix)
  * 
  */
 public class DropEvent extends
@@ -37,8 +39,8 @@ public class DropEvent extends
     super(ctx);
   }
 
-  public DropEvent(Element droppable, Element draggable) {
-    super(droppable, draggable);
+  public DropEvent(Element droppable, DragContext dragCtx) {
+    super(droppable, dragCtx);
   }
 
   @Override

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DropEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/DropEvent.java
@@ -23,7 +23,7 @@ import gwtquery.plugins.draggable.client.events.DragContext;
 /**
  * Event fired when an acceptable draggable is dropped on a droppable.
  * 
- * @author Julien Dramaix (julien.dramaix@gmail.com, @jdramaix)
+ * @author Julien Dramaix (julien.dramaix@gmail.com)
  * 
  */
 public class DropEvent extends

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/OutDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/OutDroppableEvent.java
@@ -18,6 +18,8 @@ package gwtquery.plugins.droppable.client.events;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 
+import gwtquery.plugins.draggable.client.events.DragContext;
+
 /**
  * Event fired when an acceptable draggable is being dragged out of the droppable.
  * 
@@ -37,8 +39,8 @@ public class OutDroppableEvent extends
     super(ctx);
   }
 
-  public OutDroppableEvent(Element droppable, Element draggable) {
-    super(droppable, draggable);
+  public OutDroppableEvent(Element droppable, DragContext dragCtx) {
+    super(droppable, dragCtx);
   }
 
   @Override

--- a/plugin/src/main/java/gwtquery/plugins/droppable/client/events/OverDroppableEvent.java
+++ b/plugin/src/main/java/gwtquery/plugins/droppable/client/events/OverDroppableEvent.java
@@ -18,6 +18,8 @@ package gwtquery.plugins.droppable.client.events;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 
+import gwtquery.plugins.draggable.client.events.DragContext;
+
 /**
  * Event fired when an acceptable draggable is being dragged over a droppable.
  * 
@@ -33,8 +35,8 @@ public class OverDroppableEvent extends
 
   public static Type<OverDroppableEventHandler> TYPE = new Type<OverDroppableEventHandler>();
 
-  public OverDroppableEvent(Element droppable, Element draggable) {
-    super(droppable, draggable);
+  public OverDroppableEvent(Element droppable, DragContext dragCtx) {
+    super(droppable, dragCtx);
   }
 
   public OverDroppableEvent(DragAndDropContext ctx) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -11,10 +11,10 @@
     <name>Droppable plugin project compatible GWT 2.7</name>
     <groupId>com.arcbees.gquery</groupId>
     <artifactId>droppable-plugin</artifactId>
-    <packaging>pom</packaging>
+	<packaging>pom</packaging>
     <version>2.0-SNAPSHOT</version>
 
-    <properties>
+	<properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
@@ -24,79 +24,79 @@
         <draggable.version>1.0.4</draggable.version>
 
         <junit.version>4.12</junit.version>
-    </properties>
+	</properties>
 
-    <repositories>
-        <repository>
-            <id>sonatype</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>sonatype</id>
+			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+	</repositories>
 
-    <scm>
+	<scm>
         <connection>scm:git:git@github.com:ArcBees/gwtquery-droppable-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:ArcBees/gwtquery-droppable-plugin.git</developerConnection>
         <url>https://github.com/ArcBees/gwtquery-droppable-plugin</url>
-    </scm>
+	</scm>
 
-    <issueManagement>
+	<issueManagement>
         <system>GitHub</system>
         <url>https://github.com/ArcBees/gwtquery-droppable-plugin/issues</url>
-    </issueManagement>
+	</issueManagement>
 
     <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
+			<scope>test</scope>
+		</dependency>
 
-            <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-user</artifactId>
+		<dependency>
+			<groupId>com.google.gwt</groupId>
+			<artifactId>gwt-user</artifactId>
                 <version>${gwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-dev</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.gwt</groupId>
+			<artifactId>gwt-dev</artifactId>
                 <version>${gwt.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.googlecode.gwtquery</groupId>
-                <artifactId>gwtquery</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.googlecode.gwtquery</groupId>
+			<artifactId>gwtquery</artifactId>
                 <version>${gquery.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.googlecode.gwtquery.plugins</groupId>
-                <artifactId>draggable-plugin</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.googlecode.gwtquery.plugins</groupId>
+			<artifactId>draggable-plugin</artifactId>
                 <version>${draggable.version}</version>
-            </dependency>
-        </dependencies>
+		</dependency>
+	</dependencies>
     </dependencyManagement>
 
-    <developers>
-        <developer>
-            <id>julien.dramaix@gmail.com</id>
-            <name>Julien Dramaix</name>
-            <email>julien.dramaix@gmail.com</email>
+	<developers>
+		<developer>
+			<id>julien.dramaix@gmail.com</id>
+			<name>Julien Dramaix</name>
+			<email>julien.dramaix@gmail.com</email>
             <organization>Arcbees</organization>
             <roles>
                 <role>Author</role>
             </roles>
-        </developer>
-    </developers>
-    <modules>
-        <module>plugin</module>
+		</developer>
+	</developers>
+	<modules>
+		<module>plugin</module>
         <module>sample</module>
-    </modules>
+	</modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <gquery.version>1.4.2</gquery.version>
         <gwt.version>2.7.0</gwt.version>
-        <draggable.version>1.0.4</draggable.version>
+        <draggable.version>2.0-SNAPSHOT</draggable.version>
 
         <junit.version>4.12</junit.version>
 	</properties>
@@ -77,8 +77,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.gwtquery.plugins</groupId>
-			<artifactId>draggable-plugin</artifactId>
+                <groupId>com.arcbees.gquery</groupId>
+                <artifactId>draggable</artifactId>
                 <version>${draggable.version}</version>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -11,10 +11,10 @@
     <name>Droppable plugin project compatible GWT 2.7</name>
     <groupId>com.arcbees.gquery</groupId>
     <artifactId>droppable-plugin</artifactId>
-	<packaging>pom</packaging>
+    <packaging>pom</packaging>
     <version>2.0-SNAPSHOT</version>
 
-	<properties>
+    <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
@@ -24,79 +24,79 @@
         <draggable.version>2.0-SNAPSHOT</draggable.version>
 
         <junit.version>4.12</junit.version>
-	</properties>
+    </properties>
 
-	<repositories>
-		<repository>
-			<id>sonatype</id>
-			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>sonatype</id>
+            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
 
-	<scm>
+    <scm>
         <connection>scm:git:git@github.com:ArcBees/gwtquery-droppable-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:ArcBees/gwtquery-droppable-plugin.git</developerConnection>
         <url>https://github.com/ArcBees/gwtquery-droppable-plugin</url>
-	</scm>
+    </scm>
 
-	<issueManagement>
+    <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/ArcBees/gwtquery-droppable-plugin/issues</url>
-	</issueManagement>
+    </issueManagement>
 
     <dependencyManagement>
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
+                <scope>test</scope>
+            </dependency>
 
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-user</artifactId>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
                 <version>${gwt.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-dev</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-dev</artifactId>
                 <version>${gwt.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.googlecode.gwtquery</groupId>
-			<artifactId>gwtquery</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.gwtquery</groupId>
+                <artifactId>gwtquery</artifactId>
                 <version>${gquery.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.arcbees.gquery</groupId>
                 <artifactId>draggable</artifactId>
                 <version>${draggable.version}</version>
-		</dependency>
-	</dependencies>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 
-	<developers>
-		<developer>
-			<id>julien.dramaix@gmail.com</id>
-			<name>Julien Dramaix</name>
-			<email>julien.dramaix@gmail.com</email>
+    <developers>
+        <developer>
+            <id>julien.dramaix@gmail.com</id>
+            <name>Julien Dramaix</name>
+            <email>julien.dramaix@gmail.com</email>
             <organization>Arcbees</organization>
             <roles>
                 <role>Author</role>
             </roles>
-		</developer>
-	</developers>
-	<modules>
-		<module>plugin</module>
+        </developer>
+    </developers>
+    <modules>
+        <module>plugin</module>
         <module>sample</module>
-	</modules>
+    </modules>
 </project>

--- a/sample/src/main/java/gwtquery/plugins/droppable/MultiDropSample.gwt.xml
+++ b/sample/src/main/java/gwtquery/plugins/droppable/MultiDropSample.gwt.xml
@@ -1,0 +1,5 @@
+<module rename-to='MultiDropSample'>
+	<inherits name='gwtquery.plugins.droppable.Droppable' />
+	<inherits name='com.google.gwt.user.theme.chrome.Chrome' />
+	<entry-point class='gwtquery.plugins.droppable.client.multidropsample.MultiDropSample' />
+</module>  

--- a/sample/src/main/java/gwtquery/plugins/droppable/MultiDropSample.gwt.xml
+++ b/sample/src/main/java/gwtquery/plugins/droppable/MultiDropSample.gwt.xml
@@ -1,5 +1,5 @@
 <module rename-to='MultiDropSample'>
-	<inherits name='gwtquery.plugins.droppable.Droppable' />
-	<inherits name='com.google.gwt.user.theme.chrome.Chrome' />
-	<entry-point class='gwtquery.plugins.droppable.client.multidropsample.MultiDropSample' />
-</module>  
+    <inherits name='gwtquery.plugins.droppable.Droppable'/>
+    <inherits name='com.google.gwt.user.theme.chrome.Chrome'/>
+    <entry-point class='gwtquery.plugins.droppable.client.multidropsample.MultiDropSample'/>
+</module>

--- a/sample/src/main/java/gwtquery/plugins/droppable/client/miscellanious/Issue7Test.java
+++ b/sample/src/main/java/gwtquery/plugins/droppable/client/miscellanious/Issue7Test.java
@@ -36,7 +36,7 @@ public class Issue7Test implements EntryPoint {
         
         public void f(DragAndDropContext context) {
           $("#droppable3,#droppable2").show();
-          DragAndDropManager.getInstance().update();
+          DragAndDropManager.getInstance().update(context);
         }
       });
     }

--- a/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
+++ b/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
@@ -31,7 +31,7 @@ import gwtquery.plugins.droppable.client.events.DragAndDropContext;
 /**
  * Make any elements droppable !
  * 
- * @author Julien Dramaix (julien.dramaix@gmail.com, @jdramaix)
+ * @author Julien Dramaix (julien.dramaix@gmail.com)
  * 
  */
 public class MultiDropSample implements EntryPoint {

--- a/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
+++ b/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010 The gwtquery plugins team.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package gwtquery.plugins.droppable.client.multidropsample;
+
+import static com.google.gwt.query.client.GQuery.$;
+import static gwtquery.plugins.draggable.client.Draggable.Draggable;
+import static gwtquery.plugins.droppable.client.Droppable.Droppable;
+
+import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.dom.client.Element;
+
+import gwtquery.plugins.draggable.client.DraggableOptions;
+import gwtquery.plugins.draggable.client.DraggableOptions.GroupingMode;
+import gwtquery.plugins.droppable.client.DroppableOptions;
+import gwtquery.plugins.droppable.client.DroppableOptions.DroppableFunction;
+import gwtquery.plugins.droppable.client.events.DragAndDropContext;
+
+/**
+ * Make any elements droppable !
+ * 
+ * @author Julien Dramaix (julien.dramaix@gmail.com, @jdramaix)
+ * 
+ */
+public class MultiDropSample implements EntryPoint {
+
+  public void onModuleLoad() {
+
+    DraggableOptions dragOptions = new DraggableOptions();
+    dragOptions.setMultipleSelection(true);
+    dragOptions.setGroupingMode(GroupingMode.DOWN);
+    dragOptions.setSelectedClassName("blue-background");
+    $(".draggable").as(Draggable).draggable(dragOptions);
+
+    // create droppable options
+    DroppableOptions options = new DroppableOptions();
+
+    // function called on when a acceptable draggable is dropped on the
+    // droppable
+    options.setOnDrop(new DroppableFunction() {
+      public void f(DragAndDropContext context) {
+        StringBuilder text = new StringBuilder();
+        for (Element draggable : context.getSelectedDraggables()){
+          text.append(draggable.getId()).append(" ");
+        }
+        text.append("was dropped on me !");
+        $(context.getDroppable()).addClass("orange-background").find("p").html(
+            text.toString());
+
+      }
+    });
+    
+    options.setDraggableHoverClass("yellow-background");
+    
+    //make the element droppable
+    $("#droppable").as(Droppable).droppable(options);
+  }
+
+  
+
+}

--- a/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
+++ b/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java
@@ -35,9 +35,7 @@ import gwtquery.plugins.droppable.client.events.DragAndDropContext;
  * 
  */
 public class MultiDropSample implements EntryPoint {
-
   public void onModuleLoad() {
-
     DraggableOptions dragOptions = new DraggableOptions();
     dragOptions.setMultipleSelection(true);
     dragOptions.setGroupingMode(GroupingMode.DOWN);
@@ -58,16 +56,12 @@ public class MultiDropSample implements EntryPoint {
         text.append("was dropped on me !");
         $(context.getDroppable()).addClass("orange-background").find("p").html(
             text.toString());
-
       }
     });
-    
+
     options.setDraggableHoverClass("yellow-background");
     
     //make the element droppable
     $("#droppable").as(Droppable).droppable(options);
   }
-
-  
-
 }

--- a/sample/src/main/java/gwtquery/plugins/droppable/public/MultiDropSample.html
+++ b/sample/src/main/java/gwtquery/plugins/droppable/public/MultiDropSample.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>GwtQuery: Multi-drop example</title>
+<style type="text/css">
+body {
+	color: black;
+	font-family: Arial Unicode MS, Arial, sans-serif;
+	font-size: small;
+}
+
+.draggable {
+	width: 120px;
+	height: 100px;
+	padding: 0.5em;
+	border: black solid 1px;
+	background: #f6f6f6;
+}
+
+.demo {
+	width: 700px;
+	height: 900px;
+	margin-right: auto;
+	margin-left: auto;
+	padding: 10px;
+	border: black solid 1px;
+}
+
+.droppable {
+	width: 300px;
+	height: 300px;
+	padding: 0.5em;
+	margin: 10px;
+	background-color: #CCCCCC;
+	border: 1px solid #AAAAAA;
+    position:relative;
+    float: right;
+     margin-right: 20px;
+}
+
+.orange-background {
+	background-color: #F6A828;
+	border: 1px solid #E78F08;
+	color: white;
+}
+
+
+
+.blue-background{
+    background-color: #C1DEFD;
+    color: white;
+}
+
+.yellow-background {
+    background-color: #FFE45C;
+    border: 1px solid black;
+    color: #363636;
+}
+
+</style>
+<script language="javascript" src="MultiDropSample.nocache.js"></script>
+</head>
+<body>
+<div class="demo">
+<h1>GWTQuery Droppable plug-in : multi-drop example</h1>
+<ul style="padding: 10px 0px; list-style: none; display: block">          
+    <li style="display: inline;"><a href="../SimpleSample/SimpleSample.html">Simple example</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../VisualFeedbackSample/VisualFeedbackSample.html">Visual feedback</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../RevertAndAcceptSample/RevertAndAcceptSample.html">Revert and accept options</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../GreedySample/GreedySample.html">the "greedy" option</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../MultiDropSample/MultiDropSample.html">Multi-drop</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../TestOptionsSample/TestOptionsSample.html">The options in action</a>&nbsp;|&nbsp;</li>
+    <li style="display: inline;"><a href="../GwtSimpleSample/GwtSimpleSample.html">Examples with GWT widgets</a>&nbsp;|&nbsp;</li>
+</ul>
+<p style="clear: both; padding-top:10px;">Select many draggables (by pressing ctrl or meta key and clicking on it) and drop them on the drop target.</p>
+
+<div id="droppable" class="droppable">
+<p>I'm a drop target</p>
+</div>
+
+<div id="draggable1" class="draggable">
+<p>I'm the draggable1</p>
+</div>
+
+<div id="draggable2" class="draggable">
+<p>I'm the draggable2</p>
+</div>
+
+<div id="draggable3" class="draggable">
+<p>I'm the draggable3</p>
+</div>
+
+<div id="draggable4" class="draggable">
+<p>I'm the draggable4</p>
+</div>
+
+<div style="clear: right; margin-bottom:10px;"></div>
+<a href="http://code.google.com/p/gwtquery-plugins/source/browse/trunk/droppable/sample/src/main/java/gwtquery/plugins/droppable/client/multidropsample/MultiDropSample.java" target="_blank">Java source code</a>
+</div>
+</body>
+</html>

--- a/sample/src/main/java/gwtquery/plugins/droppable/public/MultiDropSample.html
+++ b/sample/src/main/java/gwtquery/plugins/droppable/public/MultiDropSample.html
@@ -45,8 +45,6 @@ body {
 	color: white;
 }
 
-
-
 .blue-background{
     background-color: #C1DEFD;
     color: white;


### PR DESCRIPTION
Droppable was using draggable 1.0.4. The 2.0 version on Arcbees had some changes in it's interface that was breaking Droppable. See this issue : https://github.com/ArcBees/gwtquery-droppable-plugin/issues/2

Droppable version 1.0.5 to 1.0.8 didn't seem to match the trunk from googlecode, and it seems the Github's initial version was using 1.0.8. So I checked out the initial Github version, applied the Element -> DragContext changes, then rebased on master.